### PR TITLE
feat: github / aws federation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,45 +7,74 @@ name: Tests
   workflow_dispatch: null
 
 jobs:
-  permission_check:
+  permission_check_static:
     runs-on: ubuntu-latest
     outputs:
-      can-write: '${{ steps.check.outputs.can-write }}'
-    env:
-      AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
+      can-run-static: '${{ steps.check_static.outputs.can-run-static }}'
     steps:
-      - id: check
+      - id: check_static
         run: |
-          # If the AWS_ACCESS_KEY_ID secret is MIA we can't run tests
-          if [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
-              echo "can-write=false" >> $GITHUB_OUTPUT
+          if [[ -z "${{ secrets.AWS_ACCESS_KEY_ID }}" ]]; then
+              echo "can-run-static=false" >> $GITHUB_OUTPUT
           else
-              echo "can-write=true" >> $GITHUB_OUTPUT
+              echo "can-run-static=true" >> $GITHUB_OUTPUT
           fi
-          
-  test-action:
+
+  permission_check_federated:
+    runs-on: ubuntu-latest
+    outputs:
+      can-run-federated: '${{ steps.check_federated.outputs.can-run-federated }}'
+    steps:
+      - id: check_federated
+        run: |
+          if [[ -z "${{ secrets.AWS_ROLE_ARN }}" ]]; then
+              echo "can-run-federated=false" >> $GITHUB_OUTPUT
+          else
+              echo "can-run-federated=true" >> $GITHUB_OUTPUT
+          fi
+
+  test-action-static:
     runs-on: ubuntu-latest
     needs:
-      - permission_check
-    if: needs.permission_check.outputs.can-write == 'true'
+      - permission_check_static
+    if: needs.permission_check_static.outputs.can-run-static == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Provision DCE
+      - name: Provision DCE (Static)
         uses: ./
         with:
           aws-access-key-id: '${{ secrets.AWS_ACCESS_KEY_ID }}'
           aws-secret-access-key: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
           email: colin.hutchinson+gha@observeinc.com
-
-      - name: AWS Identity (DCE)
+      - name: AWS Identity (DCE Static)
         run: aws sts get-caller-identity
-
-      - name: Decomission DCE
+      - name: Decommission DCE (Static)
         uses: ./
         with:
           action-type: decommission
           aws-access-key-id: '${{ secrets.AWS_ACCESS_KEY_ID }}'
           aws-secret-access-key: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
+          email: colin.hutchinson+gha@observeinc.com
+
+  test-action-federated:
+    runs-on: ubuntu-latest
+    needs:
+      - permission_check_federated
+    if: needs.permission_check_federated.outputs.can-run-federated == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Provision DCE (Federated)
+        uses: ./
+        with:
+          aws-role-arn: '${{ secrets.AWS_ROLE_ARN }}'
+          email: colin.hutchinson+gha@observeinc.com
+      - name: AWS Identity (DCE Federated)
+        run: aws sts get-caller-identity
+      - name: Decommission DCE (Federated)
+        uses: ./
+        with:
+          action-type: decommission
+          aws-role-arn: '${{ secrets.AWS_ROLE_ARN }}'
           email: colin.hutchinson+gha@observeinc.com

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ crash.*.log
 
 *.tfvars
 *.tfvars.json
+
+.terraform.lock.hcl

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Local .terraform directories
+**/.terraform/*
+
+*.tfstate
+*.tfstate.*
+
+crash.log
+crash.*.log
+
+*.tfvars
+*.tfvars.json

--- a/README.md
+++ b/README.md
@@ -2,17 +2,69 @@
 
 This GitHub Action provisions or decommissions a Dynamic Cloud Environment (DCE) lease. It is designed to create an ephemeral AWS account with a specified budget and duration or to clean up the lease after use.
 
+Certainly! Below is an expanded set of instructions for your Terraform module for AWS/GitHub Federation. This includes steps for super admins to set up the OIDC provider, as well as instructions for module users on how to use the module.
+
 ## Terraform Module for AWS/GitHub Federation
 
-To facilitate the setup of AWS/GitHub federation for this GitHub Action, we have provided a dedicated Terraform module. This module simplifies the process of setting up the necessary AWS IAM roles and policies, and integrating them with GitHub Actions.
+This Terraform module is designed to streamline the setup of AWS/GitHub federation, which involves setting up necessary AWS IAM roles and policies and integrating them with GitHub Actions. The module is split into two main parts: setup by a super admin (to create the OIDC provider in AWS) and usage by module users (to create the necessary roles using the module).
 
-For detailed information on how to use this module, including configuration options and usage examples, please refer to the module's [tf_github_aws_federation/README.md](README.md).
+### Super Admin Instructions: Initial Setting Up OIDC Provider
+
+As a super admin, your role is to set up the OIDC provider in AWS. This is a one-time setup that needs to be performed before module users can create the necessary roles.
+
+1. **Log in to the AWS Management Console** as an admin user.
+2. **Navigate to IAM** (Identity and Access Management).
+3. **Go to Identity Providers** and choose **Add Provider**.
+4. **Select 'OpenID Connect'** as the provider type.
+5. **Set the Provider URL** to `https://token.actions.githubusercontent.com`.
+6. **Click Get thumbprint**
+7. **Add 'sts.amazonaws.com' as an Audience**.
+8. **Complete the creation process** for the OIDC provider.
+
+### Module User Instructions: Using the Module
+
+Once the OIDC provider is set up by the super admin, module users can proceed to use the Terraform module.
+
+see main.tf and backend.tf in this repository for an example
+
+1. **Include the Module in Your Terraform Configuration**:
+
+   ```hcl
+   module "github_aws_federation" {
+     source = "./tf_github_aws_federation"  # Adjust the source path as necessary
+
+     organization = "<your-github-organization>"
+     repository   = "<your-github-repository>"
+   }
+   ```
+
+2. **Configure Required Variables**:
+   - Replace `<your-github-organization>` and `<your-github-repository>` with your actual GitHub organization and repository names.
+
+3. **Export Github token (AWS Admin)**
+
+  ```bash
+  export GITHUB_TOKEN=xxx
+  ```
+
+4. **Initialize Terraform (AWS Admin)** (if not already done):
+
+   ```bash
+   terraform init
+   ```
+
+5. **Apply the Terraform Configuration (AWS Admin)**:
+
+   ```bash
+   terraform apply
+   ```
 
 ## Inputs
 
 - `action-type`: "provision" (default) to create/login or "decommission" to end a lease.
-- `aws-access-key-id`: AWS Access Key ID (required).
-- `aws-secret-access-key`: AWS Secret Access Key (required).
+- `aws-access-key-id`: AWS Access Key ID (semi-required).
+- `aws-secret-access-key`: AWS Secret Access Key (semi-required).
+- `aws-role-arn`: ARN of the AWS IAM role for federated access via GitHub Actions. Use in place of static AWS credentials (semi-required).
 - `budget-amount`: Budget amount for the lease (default: '10').
 - `budget-currency`: Currency for the budget amount (default: 'USD').
 - `email`: Email for notifications.
@@ -22,6 +74,8 @@ For detailed information on how to use this module, including configuration opti
 - `dce-region`: AWS region for DCE (default: 'us-west-2').
 - `dce-cli-version`: Version of the DCE CLI to use (default: 'v0.5.0').
 - `dce-cli-sha`: SHA256 checksum for the DCE CLI zip (default: provided checksum).
+
+The action must be provided either the aws-role-arn or access key / secret
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This GitHub Action provisions or decommissions a Dynamic Cloud Environment (DCE) lease. It is designed to create an ephemeral AWS account with a specified budget and duration or to clean up the lease after use.
 
+## Terraform Module for AWS/GitHub Federation
+
+To facilitate the setup of AWS/GitHub federation for this GitHub Action, we have provided a dedicated Terraform module. This module simplifies the process of setting up the necessary AWS IAM roles and policies, and integrating them with GitHub Actions.
+
+For detailed information on how to use this module, including configuration options and usage examples, please refer to the module's [tf_github_aws_federation/README.md](README.md).
+
 ## Inputs
 
 - `action-type`: "provision" (default) to create/login or "decommission" to end a lease.

--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,10 @@ inputs:
     description: 'AWS Secret Access Key'
     required: true
     secrets: true
+  aws-role-arn:
+    description: 'AWS Role ARN for federated access (optional)'
+    required: false
+    secrets: true
   budget-amount:
     description: 'Budget amount for the lease'
     required: false
@@ -92,11 +96,18 @@ runs:
         region: ${{ inputs.dce-region }}
         EOF
 
-    - name: Setup AWS credentials (original)
+    - name: Setup AWS credentials (original static)
       uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.dce-region }}
+
+    - name: Setup AWS Credentials (original federation)
+      if: inputs.aws-role-arn != ''
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.dce-region }}
 
     - name: AWS Identity (original)

--- a/backend.tf
+++ b/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "observe-github-dce-federation-tf-state"
+    region = "us-west-2"
+    key    = "github.com/observeinc/github-action-dce"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "github_aws_federation" {
+  source = "./tf_github_aws_federation"
+  organization = "hutchic-observe-meta"
+  repository   = "github-action-dce.git"
+}

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,6 @@ provider "aws" {
 
 module "github_aws_federation" {
   source = "./tf_github_aws_federation"
-  organization = "hutchic-observe-meta"
+  organization = "observeinc"
   repository   = "github-action-dce.git"
 }

--- a/tf_github_aws_federation/README.md
+++ b/tf_github_aws_federation/README.md
@@ -1,0 +1,43 @@
+# DCE Github Actions Terraform
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 5 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5 |
+| <a name="provider_github"></a> [github](#provider\_github) | ~> 5 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.github_actions_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.dce_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [github_actions_secret.aws_ci_role](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_secret) | resource |
+| [aws_iam_openid_connect_provider.github_actions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
+| [aws_iam_policy_document.github_actions_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_organization"></a> [organization](#input\_organization) | The GitHub organization name. | `string` | n/a | yes |
+| <a name="input_repository"></a> [repository](#input\_repository) | The GitHub repository name. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | The ARN of the IAM role created for GitHub Actions. |

--- a/tf_github_aws_federation/main.tf
+++ b/tf_github_aws_federation/main.tf
@@ -1,0 +1,52 @@
+data "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+locals {
+  oidc_claim_prefix = trimprefix(data.aws_iam_openid_connect_provider.github_actions.url, "https://")
+}
+
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${local.oidc_claim_prefix}:sub"
+      values   = ["repo:${var.organization}/${var.repository}:*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_claim_prefix}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions_ci" {
+  name = "${var.repository}-gha-ci"
+
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+
+  tags = {
+    Principal  = "GitHub Actions"
+    Repository = "${var.organization}/${var.repository}"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "dce_policy_attachment" {
+  role       = aws_iam_role.github_actions_ci.name
+  policy_arn = "arn:aws:iam::460044344528:policy/dce-user-playground-20230917"
+}
+
+resource "github_actions_secret" "aws_ci_role" {
+  repository      = var.repository
+  secret_name     = "AWS_ROLE_ARN"
+  plaintext_value = aws_iam_role.github_actions_ci.arn
+}

--- a/tf_github_aws_federation/outputs.tf
+++ b/tf_github_aws_federation/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  description = "The ARN of the IAM role created for GitHub Actions."
+  value       = aws_iam_role.github_actions_ci.arn
+}

--- a/tf_github_aws_federation/providers.tf
+++ b/tf_github_aws_federation/providers.tf
@@ -1,0 +1,3 @@
+provider "github" {
+  owner = local.organization
+}

--- a/tf_github_aws_federation/providers.tf
+++ b/tf_github_aws_federation/providers.tf
@@ -1,3 +1,3 @@
 provider "github" {
-  owner = local.organization
+  owner = var.organization
 }

--- a/tf_github_aws_federation/variables.tf
+++ b/tf_github_aws_federation/variables.tf
@@ -1,0 +1,9 @@
+variable "organization" {
+  description = "The GitHub organization name."
+  type        = string
+}
+
+variable "repository" {
+  description = "The GitHub repository name."
+  type        = string
+}

--- a/tf_github_aws_federation/versions.tf
+++ b/tf_github_aws_federation/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.1.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 5"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}


### PR DESCRIPTION
introduces a terraform module that will create a role in blunderdome so we can avoid static aws credentials.